### PR TITLE
fix(nav): align prev/next titles; remove empty navigation.yml

### DIFF
--- a/docs/_includes/page-navigation.html
+++ b/docs/_includes/page-navigation.html
@@ -17,7 +17,10 @@ we suppress rendering of bottom navigation to unify top-page behavior.
 {%- assign _baseurl = site.baseurl | default: '' -%}
 {%- assign _page_url_n = page.url -%}
 {%- if _baseurl and _baseurl != '' -%}
-  {%- assign _page_url_n = _page_url_n | remove_first: _baseurl -%}
+  {%- assign _page_url_prefix = _page_url_n | slice: 0, _baseurl.size -%}
+  {%- if _page_url_prefix == _baseurl -%}
+    {%- assign _page_url_n = _page_url_n | slice: _baseurl.size, _page_url_n.size -%}
+  {%- endif -%}
 {%- endif -%}
 {%- assign _is_root = false -%}
 {%- if _page_url_n == '/' or _page_url_n == '' -%}


### PR DESCRIPTION
- Use latest canonical bottom navigation include (prefers page.title)\n- Remove empty docs/_data/navigation.yml to avoid overriding navigation.json or site.pages\n- No content changes; navigation display consistency only