### PR TITLE
fix: docs/_config.yml permalink/plugins

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -15,6 +15,8 @@ plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-remote-theme
+  - jekyll-relative-links
+  - jekyll-optional-front-matter
 
 # 除外ファイル
 exclude:
@@ -39,8 +41,6 @@ url: "https://itdojp.github.io"
 baseurl: "/LogicalThinking-AI-Era-Guide"
 repository: "itdojp/LogicalThinking-AI-Era-Guide"
 permalink: pretty
-  - jekyll-relative-links
-  - jekyll-optional-front-matter
 # Use custom book layout as default
 defaults:
   - scope:


### PR DESCRIPTION
`docs/_config.yml` の `permalink` にプラグイン名が混入していたため、設定を分離しました。

- `permalink: pretty` に修正
- `plugins` に `jekyll-relative-links` / `jekyll-optional-front-matter` を追加

Jekyll の設定解釈が安定し、GitHub Pages/ビルド時の予期せぬ挙動を避けることを意図しています。
