### PR TITLE
docs: READMEを読者入口に差し替え

### DIFF
--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -1,170 +1,48 @@
-# 🚀 Quick Start Guide - 5分で始める書籍出版
+# Quick Start（執筆・開発者向け）
 
-> **改善版テンプレート**: 複雑な設定を自動化し、すぐに執筆を開始できます
+このリポジトリの内容をローカルでプレビューするための最小手順です。
 
-## ⚡ 超高速セットアップ
+## 前提
 
-### Step 1: テンプレートをクローン
+- Node.js 18 以上（`package.json` の `engines.node` を参照）
+- Ruby と Bundler（`docs/Gemfile` を参照）
 
-```bash
-git clone https://github.com/itdojp/book-publishing-template2.git my-book
-cd my-book
-```
-
-### Step 2: 自動セットアップ実行
+## セットアップ
 
 ```bash
-# Node.js 18以上が必要
-node easy-setup.js
+git clone https://github.com/itdojp/LogicalThinking-AI-Era-Guide.git
+cd LogicalThinking-AI-Era-Guide
+
+npm ci
+
+cd docs
+bundle install
+cd ..
 ```
 
-**質問に答えるだけ**: 書籍タイトル、著者名、GitHubユーザー名を入力
-
-### Step 3: ビルドテスト
+## ローカルプレビュー（推奨）
 
 ```bash
-npm run build
-npm run preview
+npm start
 ```
 
-ブラウザで http://localhost:8080 を開いて確認
+起動後に表示される URL で閲覧できます（`docs/_config.yml` の `baseurl` 設定によりパスが付与される場合があります）。
 
-### Step 4: GitHubへプッシュ
-
-```bash
-git add -A
-git commit -m "Initial commit"
-# GitHubでリポジトリを作成後
-# git remote add origin https://github.com/yourusername/my-book.git
-git push -u origin main
-```
-
-### Step 5: GitHub Pages設定（1分）
-
-1. GitHubのリポジトリページを開く
-2. **Settings** > **Pages** へ移動
-3. **Source**: Deploy from a branch
-4. **Branch**: main, **Folder**: /docs
-5. **Save** をクリック
-
-**完了！** 数分後に `https://yourusername.github.io/my-book/` でアクセス可能
-
----
-
-## 📝 執筆開始
-
-### ディレクトリ構造
-
-```
-my-book/
-├── src/
-│   ├── introduction/index.md    # はじめに
-│   └── chapters/
-│       └── chapter01/index.md   # 第1章
-├── assets/images/               # 画像
-└── book-config.json            # 設定
-```
-
-### 新しい章を追加
-
-```bash
-mkdir src/chapters/chapter02
-echo "# 第2章 応用編
-
-詳細な内容..." > src/chapters/chapter02/index.md
-```
-
-### 数式を追加
-
-```markdown
-$$E = mc^2$$
-
-インライン数式: $x = \frac{-b \pm \sqrt{b^2-4ac}}{2a}$
-```
-
-### 図表を追加
-
-```markdown
-```mermaid
-graph TD
-    A[開始] --> B{条件}
-    B -->|Yes| C[処理A]
-    B -->|No| D[処理B]
-```\
-```
-
----
-
-## 🔄 日常ワークフロー
-
-### 1. 執筆
-
-```bash
-# ファイルを編集
-vim src/chapters/chapter01/index.md
-```
-
-### 2. プレビュー
+## ビルドと静的プレビュー
 
 ```bash
 npm run preview
-# http://localhost:8080 で確認
 ```
 
-### 3. 公開
+このコマンドは `npm run build`（`docs/_site/` を生成）を実行したうえで、静的ファイルサーバーでプレビューします。
+
+## どこを編集するか
+
+- 公開ページのソース: `docs/`
+- 原稿整理用ファイル: `src/`（運用は要確認）
+
+## リント・リンクチェック（任意）
 
 ```bash
-npm run build  # docs/フォルダにビルド
-git add .
-git commit -m "Add new content"
-git push
-
-# GitHub Actionsで自動ビルド（オプション）
+npm test
 ```
-
----
-
-## ❓ トラブルシューティング
-
-### ビルドエラー
-
-```bash
-npm run clean
-npm run build
-```
-
-### GitHub Pagesが表示されない
-
-1. Settings > Pages で設定を確認
-2. Branch: main, Folder: /docs が選択されているか確認
-3. ビルド後に`docs/`フォルダがコミットされているか確認
-
-### プレビューが表示されない
-
-```bash
-# ポート8080が使用中の場合
-npx http-server docs -p 3000
-```
-
----
-
-## 📚 さらに詳しく
-
-- **完全ガイド**: [README.md](README.md)
-- **リポジトリ構成**: [REPOSITORY-ACCESS-GUIDE.md](REPOSITORY-ACCESS-GUIDE.md)
-- **設定詳細**: [book-config.json](book-config.json)
-- **サポート**: [Issues](https://github.com/itdojp/book-publishing-template2/issues)
-
----
-
-## 🎯 改善ポイント
-
-このテンプレートの改善点:
-
-- ✅ **1コマンドセットアップ**: `node easy-setup.js`
-- ✅ **軽量ビルド**: 重い依存関係を排除
-- ✅ **明確なエラーメッセージ**: 問題箇所が分かりやすい
-- ✅ **自動設定生成**: 手動設定を最小化
-- ✅ **段階的セットアップ**: 必要な時に高度な機能を追加
-
-**Happy Writing! 📖✨**

--- a/README.md
+++ b/README.md
@@ -1,207 +1,38 @@
-# 📚 Book Publishing Template v2.0 - 改善版
+# AI時代に差がつく論理的思考と表現力
 
-> **大幅に使いやすくなった書籍出版テンプレート**
+生成AIを使いこなすための基礎スキルとして、ビジネス現場で求められる論理的思考・表現・AI協働を体系的に学ぶためのガイドです。
 
-## 🎯 改善ポイント
+- 公開ページ（GitHub Pages）: https://itdojp.github.io/LogicalThinking-AI-Era-Guide/
+- 目次（リポジトリ内）: `docs/index.md`
+- シリーズ: https://github.com/itdojp/it-engineer-knowledge-architecture
 
-### 1. **ワンコマンドセットアップ** 🚀
-```bash
-node easy-setup.js
-```
-- 対話式で簡単
-- 自動で設定ファイル生成
-- 日本語メッセージ
+## この本でできるようになること
 
-### 2. **軽量ビルドシステム** ⚡
-```bash
-node scripts/build-simple.js
-```
-- 依存関係エラーなし
-- 高速ビルド
-- 分かりやすいエラー
+- 日常業務や会議、プレゼンテーションの場面で、「結論→理由→具体例」のような基本的な論理構造を意識して説明できるようになる。
+- 生成AIに対して、目的・前提・制約条件を明確にした指示を出し、アウトプットを評価・修正しながら活用できるようになる。
+- 自分や相手の主張を、前提・根拠・反論可能性といった観点から整理し、感情論ではなく論理に基づいて議論できるようになる。
+- 問題解決や意思決定の場面で、選択肢と評価軸を可視化し、納得感のある判断プロセスを説明できるようになる。
 
-### 3. **最小限の依存関係** 📦
-```json
-// package-simple.json
-{
-  "dependencies": {
-    "fs-extra": "^11.1.0",
-    "gray-matter": "^4.0.3"
-  }
-}
-```
+## 対象読者
 
-### 4. **5分で始められる** ⏱️
-- [QUICK-START.md](QUICK-START.md) - 超簡単ガイド
-- 複雑な設定不要
-- すぐに執筆開始
+- 技術職以外の一般会社員（営業、企画、人事、経理、マーケティング等）
+- 生成AIツールを業務で使い始めた、または使う予定の方
+- 論理的思考に苦手意識がある方
 
-### 5. **GitHub Pages自動設定** 🔧
-- GitHub Actionsワークフロー自動生成
-- 2つの設定方式に対応（Legacy/Actions）
-- 404エラー対策済み
+## 読み方の目安
 
-## 📋 主な改善内容
+- 論理的思考そのものに苦手意識がある読者は、第1部（第1〜4章）を通読して基礎を固めてから、第2部以降に進むと理解しやすい。
+- 「AIとの対話」に関心が高い読者は、第1章で全体像を押さえたうえで、第2部（第5〜9章）を先に読んでもよい。
+- 実務での活用イメージを重視したい読者は、第1〜2部で基礎とAIとの対話を一通り確認した後、第3部（第10〜14章）を重点的に読むとよい。
 
-| 項目 | 改善前 | 改善後 |
-|------|--------|--------|
-| **初期設定** | 5段階の手動設定 | 1コマンド |
-| **エラーメッセージ** | 英語・技術的 | 日本語・分かりやすい |
-| **依存関係** | 重い・エラー多発 | 軽量・安定 |
-| **ビルド時間** | 遅い | 高速 |
-| **必要な知識** | 高度 | 基本的 |
-| **リポジトリ構成** | デュアル（複雑） | 単一（シンプル） |
-| **トークン設定** | 必須 | 不要 |
+## フィードバック（誤り指摘・改善提案）
 
-## 🚀 使い方
+誤字脱字、技術的な誤り、改善提案は Issues / Pull Request で受け付けます。手順は `CONTRIBUTING.md` を参照してください。
 
-### 1. セットアップ（1分）
-```bash
-git clone https://github.com/itdojp/book-publishing-template2.git my-book
-cd my-book
-node easy-setup.js
-```
+## ローカルプレビュー（貢献者向け）
 
-### 2. 執筆
-```bash
-# src/chapters/chapter01/index.md を編集
-```
+ローカルでのプレビュー手順は `QUICK-START.md` を参照してください。
 
-### 3. ビルド&プレビュー
-```bash
-npm run build
-npm run preview
-```
+## ライセンス
 
-### 4. GitHub Pages設定
-```bash
-git add -A
-git commit -m "Initial commit"
-git push
-
-# GitHubで: Settings > Pages > Source: main branch /docs folder
-```
-
-## 📁 シンプルな構造
-
-```
-my-book/
-├── src/               # 原稿
-│   ├── introduction/  # はじめに
-│   └── chapters/      # 各章
-├── docs/              # ビルド出力（GitHub Pages用）
-├── assets/           # 画像
-├── easy-setup.js     # セットアップツール
-└── book-config.json  # 設定ファイル
-```
-
-## 🔧 カスタマイズ
-
-必要に応じて、次の高度な機能を追加できます。
-- `package.json` - フル機能版
-- `scripts/build.js` - 高度なビルド
-- プラグインシステム
-- テーマシステム
-
-## 📚 ドキュメント
-
-### 🚀 クイックスタート
-- [QUICK-START.md](QUICK-START.md) - 5分で始める
-- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - トラブルシューティング
-
-### 📖 詳細ガイド
-- [REPOSITORY-ACCESS-GUIDE.md](REPOSITORY-ACCESS-GUIDE.md) - リポジトリ構成とアクセス権
-- [MIGRATION-PLAN.md](MIGRATION-PLAN.md) - 既存版からの移行
-- [UPGRADE-GUIDE.md](UPGRADE-GUIDE.md) - アップグレードガイド
-- [COMPARISON.md](COMPARISON.md) - 既存版との比較
-
-### 🔧 技術ドキュメント
-- [Docs/](Docs/) - 詳細技術ドキュメント
-- [TECHNICAL-CONTEXT.md](TECHNICAL-CONTEXT.md) - 技術的背景
-- [FEEDBACK-COLLECTION.md](FEEDBACK-COLLECTION.md) - フィードバック収集計画
-
-## 🔧 GitHub Actions ワークフロー管理
-
-### 問題のあるワークフローを無効化
-
-テンプレートを使用する際、不要なワークフローが原因でActionsがハングアップすることがあります。
-
-```bash
-npm run configure:workflows
-```
-
-このコマンドで以下のワークフローを自動無効化します。
-- `content-validation.yml` (リンクチェックでハングアップ)
-- `quality-checks.yml` (長時間実行)
-- `build-with-cache.yml` (重複ビルド)
-- `parallel-build-test.yml` (テスト用)
-- `validate-secrets.yml` (設定複雑)
-
-### 推奨ワークフロー構成
-
-本番環境では`build.yml`のみを有効にすることを推奨します。
-- GitHub Pagesへの自動デプロイ
-- 最小限のビルド時間
-- エラーが少ない安定動作
-
-## 🚨 Jekyll Liquid構文競合対策
-
-### 問題の説明
-
-Podmanやコンテナ関連の技術書では、以下のような構文がJekyll Liquidテンプレートと競合することがあります。
-
-```markdown
-# 問題となる構文例
-{{.Container}}          # Podmanフォーマット文字列
-{{app="myapp"}}         # Prometheus クエリ
-{{$labels.name}}        # アラート設定
-```
-
-### 自動検出・修正ツール
-
-```bash
-# 競合をチェック
-npm run check-conflicts
-
-# 自動修正
-npm run fix-conflicts
-
-# 競合対策付きビルド
-npm run build:safe
-```
-
-### 手動修正方法
-
-Jekyll Liquidと競合する `{{}}` は `\{\{\}\}` にエスケープします。
-
-```markdown
-# 修正前
-query = 'rate(http_requests_total{{app="myapp"}}[5m])'
-
-# 修正後  
-query = 'rate(http_requests_total\{\{app="myapp"\}\}[5m])'
-```
-
-### 対策が自動適用されるパターン
-
-- Container Format Strings: `{{.Container}}`, `{{.Names}}`
-- Prometheus Queries: `{{app="..."}}`
-- Template Variables: `{{variable}}`
-- Kubernetes Templates: `{{template "..."}}`
-
-## 🤝 サポート
-
-- Issues: https://github.com/itdojp/book-publishing-template2/issues
-- 元のテンプレート: https://github.com/itdojp/book-publishing-template
-
-## ✨ 特徴
-
-- ✅ **初心者に優しい**: 技術的な知識不要
-- ✅ **高速**: 軽量で高速なビルド
-- ✅ **柔軟**: 必要に応じて拡張可能
-- ✅ **安定**: エラーが少ない
-- ✅ **日本語対応**: メッセージが分かりやすい
-
----
-
-**Happy Writing! 📖✨**
+本書は Creative Commons BY-NC-SA 4.0 で提供されています。詳細は `LICENSE.md` を参照してください。

--- a/package.json
+++ b/package.json
@@ -8,16 +8,17 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "start": "jekyll serve --livereload",
-    "build": "jekyll build",
     "build:gh-pages": "bundle exec jekyll build",
-    "preview": "npm run build && npx http-server _site -p 8080 --silent",
-    "deploy": "gh-pages -d _site",
-    "clean": "rm -rf _site .jekyll-cache",
+    "start": "cd docs && bundle exec jekyll serve --livereload",
+    "build": "cd docs && bundle exec jekyll build",
+    "build:gh-pages": "cd docs && bundle exec jekyll build",
+    "preview": "npm run build && cd docs && npx http-server _site -p 8080 --silent",
+    "deploy": "gh-pages -d docs/_site",
+    "clean": "rm -rf docs/_site docs/.jekyll-cache",
     "test": "npm run lint && npm run check-links",
-    "lint": "markdownlint 'src/**/*.md' --ignore node_modules",
-    "lint:light": "markdownlint 'src/**/*.md' --ignore node_modules",
-    "check-links": "markdown-link-check src/**/*.md",
+    "lint": "markdownlint 'docs/**/*.md' --ignore node_modules",
+    "lint:light": "markdownlint 'docs/**/*.md' --ignore node_modules",
+    "check-links": "markdown-link-check docs/**/*.md",
     "help": "echo 'Available commands:\n  npm start - Start development server\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'"
   },
   "dependencies": {


### PR DESCRIPTION
## 変更内容
- `README.md` を書籍の入口として差し替え（公開ページ、目次、対象読者、読み方、フィードバック導線）。
- `QUICK-START.md` を本リポジトリ向け（`docs/` + Jekyll）に更新。
- `package.json` の npm scripts を `docs/` を対象にする形へ整備（ローカルプレビュー/ビルドが想定通り動くように）。

## 背景 / 目的
- 「GitHub 上のトップ（README.md）を読者・学習者の入口にする」方針に合わせます。

## 補足
- `docs/index.md` の既存記述をベースに README を構成しています（企画意図・想定読者の上書きはしていません）。
- `QUICK-START.md` / `package.json` を変更しているため、同ファイルを触る既存PR（例: #65）とは競合します。不要になった場合は Close を検討してください。
