### PR TITLE
chore: make textlint blocking in Book QA

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Unicode check (fail on warnings)
         run: node book-formatter/scripts/check-unicode.js "${{ steps.scan.outputs.dir }}" --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
 
-      - name: Textlint (PRH dictionary; non-blocking by default)
-        run: node book-formatter/scripts/check-textlint.js "${{ steps.scan.outputs.dir }}" --fail-on none
+      - name: Textlint (PRH dictionary; fail on errors)
+        run: node book-formatter/scripts/check-textlint.js "${{ steps.scan.outputs.dir }}" --fail-on error
 
       - name: Link check (internal + anchors)
         run: node book-formatter/scripts/check-links.js "${{ steps.scan.outputs.dir }}"


### PR DESCRIPTION
## 目的
Book QA の textlint(PRH) を「高確度ルールのみブロック」に切り替え、表記揺れ（GitHub/JavaScript/TypeScript/PostgreSQL）をCIで抑止します。

## 変更点
- `.github/workflows/book-qa.yml` の textlint を `--fail-on error` に変更
  - common PRH辞書（book-formatter）に定義されている高確度ルールのみが対象

## 関連
- itdojp/book-formatter#66
- itdojp/it-engineer-knowledge-architecture#102
