### PR TITLE
CI記述例の公式GitHub Actions参照を更新

### DIFF
--- a/book-template-guide.md
+++ b/book-template-guide.md
@@ -91,7 +91,7 @@ jobs:
 
       # 出力先は書籍の構成に合わせて調整（例: Jekyllなら docs/_site）
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./docs/_site
 


### PR DESCRIPTION
## 概要
- 書籍本文および関連テンプレートに残る、公式 GitHub Actions の旧メジャー参照を更新
- このPRで実際に存在する記述のみを更新（存在しない記述は変更なし）

## 対象方針
- `actions/cache@v3` -> `actions/cache@v4`
- `actions/upload-artifact@v3` -> `actions/upload-artifact@v4`
- `actions/download-artifact@v3` -> `actions/download-artifact@v4`
- `actions/upload-pages-artifact@v2|v3` -> `actions/upload-pages-artifact@v4`
- `actions/deploy-pages@v2` -> `actions/deploy-pages@v4`
- `actions/dependency-review-action@v3` -> `actions/dependency-review-action@v4`
- `actions/configure-pages@v3` -> `actions/configure-pages@v5`

## 補足
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
- 書籍の記述例・テンプレート更新が主目的です。