### PR TITLE
ci: actions/setup-node を v6 に更新（workflow）

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -24,7 +24,7 @@ jobs:
           path: book-formatter
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm

--- a/book-template-guide.md
+++ b/book-template-guide.md
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
- `.github/workflows/book-qa.yml` と `book-template-guide.md` の `actions/setup-node@v4` を `@v6` に更新
- 変更範囲は workflow 定義/記載のみ

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102