### PR TITLE
docs: ナビ/ライセンスの装飾絵文字を削除

### DIFF
--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -63,7 +63,6 @@
     {% endif %}
     
     <a href="{{ site.baseurl }}/" class="nav-home">
-      <span class="icon">📚</span>
       <span class="label">目次へ</span>
     </a>
     
@@ -170,11 +169,6 @@
 
 .nav-next .arrow {
   margin-left: 0.5rem;
-}
-
-.nav-home .icon {
-  margin-right: 0.5rem;
-  font-size: 1.2rem;
 }
 
 .label {

--- a/docs/assets/images/README-IMAGES.md
+++ b/docs/assets/images/README-IMAGES.md
@@ -4,14 +4,14 @@ This file documents the images that should be created for the README.md GitHub c
 
 ## Required Images
 
-### 1. ✅ book-publishing-template-use-this.png (Available)
+### 1. book-publishing-template-use-this.png (Available)
 **Description:** Screenshot of GitHub repository page showing the "Use this template" button
 **Content:**
 - Repository header with "Use this template" button highlighted with red circle
 - Shows the green "Use this template" button clearly
 - Actual size: Optimized for web display
 
-### 2. ✅ book-publishing-template-repository-name.png (Available)
+### 2. book-publishing-template-repository-name.png (Available)
 **Description:** Screenshot of the "Create a new repository" form
 **Content:**
 - Repository template selection showing "itdojp/book-publishing-template"

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,10 +93,10 @@ permalink: /
 
 ## ライセンス
 
-本書は **Creative Commons BY-NC-SA 4.0** ライセンスで公開されています。  
-**🔓 教育・研究・個人学習での利用は自由** ですが、**💼 商用利用には事前許諾** が必要です。
+本書は **Creative Commons BY-NC-SA 4.0** ライセンスで公開しています。  
+教育・研究・個人学習での利用は自由ですが、商用利用は別途契約（事前許諾）が必要です。
 
-📋 [詳細なライセンス条件](https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md)
+[詳細なライセンス条件](https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md)
 
 **お問い合わせ**  
 株式会社アイティードゥ（ITDO Inc.）  


### PR DESCRIPTION
## 変更内容
- ナビゲーション（「目次へ」）のアイコン（📚）と関連CSSを削除
- トップページのライセンス表記から装飾絵文字（🔓/💼/📋）を除去し、文言を統一
- `README-IMAGES.md` の見出し装飾（✅）を除去

## 検証
- node ../book-formatter/scripts/check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
- node ../book-formatter/scripts/check-textlint.js docs --fail-on error
- node ../book-formatter/scripts/check-links.js docs
- node ../book-formatter/scripts/check-layout-risk.js docs --fail-on error
- node ../book-formatter/scripts/check-markdown-structure.js docs --fail-on error
