### PR TITLE
[codex] Add logical thinking metadata QA gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -33,6 +33,9 @@ jobs:
           cache: npm
           cache-dependency-path: book-formatter/package-lock.json
 
+      - name: Metadata consistency check
+        run: npm run check:metadata
+
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -65,10 +65,13 @@
 
 ```bash
 npm install
+npm run check:metadata
 npm run lint:light
 npm run check-links
 npm run build
 ```
+
+`npm run check:metadata` は `book-config.json`、`docs/_config.yml`、`docs/index.md`、`docs/_data/navigation.yml`、`package.json`、`package-lock.json` の公開情報を照合し、章・付録の経路と必須アセットの欠落を検出します。
 
 `npm run check-links` は `.markdown-link-check.json` により外部URL（`https://` など）を対象外とし、リポジトリ内リンクの破綻検出を主目的としています。
 

--- a/book-config.json
+++ b/book-config.json
@@ -14,94 +14,112 @@
       {
         "id": "chapter01",
         "title": "第1章：なぜ今、論理的思考が必要なのか",
-        "description": "AI時代に論理的思考が差を生む理由を、成果物・判断・説明責任に接続する"
+        "description": "AI時代に論理的思考が差を生む理由を、成果物・判断・説明責任に接続する",
+        "path": "/chapters/chapter01/"
       },
       {
         "id": "chapter02",
         "title": "第2章：論理的思考の基本構造",
-        "description": "前提・論点・根拠・反論・結論の構造を整理する"
+        "description": "前提・論点・根拠・反論・結論の構造を整理する",
+        "path": "/chapters/chapter02/"
       },
       {
         "id": "chapter03",
         "title": "第3章：情報の整理と分析",
-        "description": "事実・解釈・仮説・推定・推奨を分け、根拠確認につなげる"
+        "description": "事実・解釈・仮説・推定・推奨を分け、根拠確認につなげる",
+        "path": "/chapters/chapter03/"
       },
       {
         "id": "chapter04",
         "title": "第4章：問題解決の論理プロセス",
-        "description": "問題設定・仮説・意思決定・評価軸を、AI出力の採否判断へ接続する"
+        "description": "問題設定・仮説・意思決定・評価軸を、AI出力の採否判断へ接続する",
+        "path": "/chapters/chapter04/"
       },
       {
         "id": "chapter05",
         "title": "第5章：AIへの指示（プロンプト）設計",
-        "description": "task brief・context design・output schema・受け入れ基準として指示設計を扱う"
+        "description": "task brief・context design・output schema・受け入れ基準として指示設計を扱う",
+        "path": "/chapters/chapter05/"
       },
       {
         "id": "chapter06",
         "title": "第6章：AIの出力を評価・改善する",
-        "description": "CAREを根拠・リスク・承認・評価ログまで含む実務評価へ拡張する"
+        "description": "CAREを根拠・リスク・承認・評価ログまで含む実務評価へ拡張する",
+        "path": "/chapters/chapter06/"
       },
       {
         "id": "chapter07",
         "title": "第7章：批判的思考とメディアリテラシー",
-        "description": "誤情報・synthetic content・provenance・source hierarchyを検証する"
+        "description": "誤情報・synthetic content・provenance・source hierarchyを検証する",
+        "path": "/chapters/chapter07/"
       },
       {
         "id": "chapter08",
         "title": "第8章：AI活用の具体的場面",
-        "description": "research・drafting・analysis・meeting・proposal・multimodalを標準フローへ組み込む"
+        "description": "research・drafting・analysis・meeting・proposal・multimodalを標準フローへ組み込む",
+        "path": "/chapters/chapter08/"
       },
       {
         "id": "chapter09",
         "title": "第9章：AIリスク管理と倫理的配慮",
-        "description": "data classification・prompt injection・privacy・IP・policy・監査ログを扱う"
+        "description": "data classification・prompt injection・privacy・IP・policy・監査ログを扱う",
+        "path": "/chapters/chapter09/"
       },
       {
         "id": "chapter10",
         "title": "第10章：論理的な文書作成",
-        "description": "1枚サマリー・提案書・報告書・稟議メモを成果物として作る"
+        "description": "1枚サマリー・提案書・報告書・稟議メモを成果物として作る",
+        "path": "/chapters/chapter10/"
       },
       {
         "id": "chapter11",
         "title": "第11章：説得力のあるプレゼンテーション",
-        "description": "プレゼン・経営説明・想定Q&Aを設計する"
+        "description": "プレゼン・経営説明・想定Q&Aを設計する",
+        "path": "/chapters/chapter11/"
       },
       {
         "id": "chapter12",
         "title": "第12章：効果的な会議・議論術",
-        "description": "会議設計・議事録・意思決定ログ・合意形成を扱う"
+        "description": "会議設計・議事録・意思決定ログ・合意形成を扱う",
+        "path": "/chapters/chapter12/"
       },
       {
         "id": "chapter13",
         "title": "第13章：論理的な交渉・説得術",
-        "description": "営業ヒアリング・提案骨子・反論処理・交渉を扱う"
+        "description": "営業ヒアリング・提案骨子・反論処理・交渉を扱う",
+        "path": "/chapters/chapter13/"
       },
       {
         "id": "chapter14",
         "title": "第14章：日常業務での実践",
-        "description": "PDF・画像・表・グラフ・スクリーンショットを含む日常業務のマルチモーダル活用を扱う"
+        "description": "PDF・画像・表・グラフ・スクリーンショットを含む日常業務のマルチモーダル活用を扱う",
+        "path": "/chapters/chapter14/"
       },
       {
         "id": "chapter15",
         "title": "第15章：論理的思考を活かしたリーダーシップ",
-        "description": "テンプレート・プロンプト資産・レビュー・責任分界をチーム運用として扱う"
+        "description": "テンプレート・プロンプト資産・レビュー・責任分界をチーム運用として扱う",
+        "path": "/chapters/chapter15/"
       },
       {
         "id": "chapter16",
         "title": "第16章：プロジェクト管理と問題解決",
-        "description": "KPI・評価・導入計画・変更管理をプロジェクト推進へ接続する"
+        "description": "KPI・評価・導入計画・変更管理をプロジェクト推進へ接続する",
+        "path": "/chapters/chapter16/"
       },
       {
         "id": "chapter17",
         "title": "第17章：継続的学習と思考力向上",
-        "description": "継続学習・能力開発・更新確認・テンプレート廃止ルールを扱う"
+        "description": "継続学習・能力開発・更新確認・テンプレート廃止ルールを扱う",
+        "path": "/chapters/chapter17/"
       }
     ],
     "appendices": [
       {
         "id": "appendix-a",
         "title": "付録A：実践的なツール・テンプレート集",
-        "description": "task brief、data classification、output schema、evaluation rubric、fact-check log、decision memo、governance checklistを含む実務オペレーティングキット"
+        "description": "task brief、data classification、output schema、evaluation rubric、fact-check log、decision memo、governance checklistを含む実務オペレーティングキット",
+        "path": "/appendices/appendix-a/"
       }
     ]
   },
@@ -128,5 +146,6 @@
   "shared": {
     "version": "3.2.2",
     "lastSync": "2026-02-04T23:01:47.781Z"
-  }
+  },
+  "homepage": "https://itdojp.github.io/LogicalThinking-AI-Era-Guide/"
 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 title: "AI時代に差がつく論理的思考と表現力"
-description: "AIを使った業務成果物を、根拠確認・評価・承認・再利用まで含めて仕上げるための実践ガイド"
-author: "株式会社アイティードゥ"
+description: "AIを使った業務成果物を、タスク定義・情報分類・根拠確認・評価・承認・再利用まで含めて仕上げるための論理的思考と表現力の実践ガイド"
+author: "ITDO Inc.（株式会社アイティードゥ）"
 version: "1.0.0"
 lang: "ja"
 
@@ -39,6 +39,9 @@ kramdown:
 # GitHub Pages設定
 url: "https://itdojp.github.io"
 baseurl: "/LogicalThinking-AI-Era-Guide"
+license: "CC-BY-NC-SA-4.0"
+homepage: "https://itdojp.github.io/LogicalThinking-AI-Era-Guide/"
+repository_url: "https://github.com/itdojp/LogicalThinking-AI-Era-Guide"
 repository: "itdojp/LogicalThinking-AI-Era-Guide"
 permalink: pretty
 # Use custom book layout as default

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,8 @@
 layout: book
 order: 1
 title: "AI時代に差がつく論理的思考と表現力"
-author: "株式会社アイティードゥ"
+description: "AIを使った業務成果物を、タスク定義・情報分類・根拠確認・評価・承認・再利用まで含めて仕上げるための論理的思考と表現力の実践ガイド"
+author: "ITDO Inc.（株式会社アイティードゥ）"
 version: "1.0.0"
 permalink: /
 ---

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
   "name": "logical-thinking-ai-era-guide",
   "version": "1.0.0",
-  "description": "AI時代に差がつく論理的思考と表現力 - 生成AIを使いこなすための基礎スキル",
+  "description": "AIを使った業務成果物を、タスク定義・情報分類・根拠確認・評価・承認・再利用まで含めて仕上げるための論理的思考と表現力の実践ガイド",
   "author": "ITDO Inc.（株式会社アイティードゥ）",
   "license": "CC-BY-NC-SA-4.0",
   "engines": {
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build:gh-pages": "bundle exec jekyll build",
+    "build:gh-pages": "cd docs && bundle exec jekyll build",
     "start": "cd docs && bundle exec jekyll serve --livereload",
     "build": "cd docs && bundle exec jekyll build",
-    "build:gh-pages": "cd docs && bundle exec jekyll build",
     "preview": "npm run build && cd docs && npx http-server _site -p 8080 --silent",
     "deploy": "gh-pages -d docs/_site",
     "clean": "rm -rf docs/_site docs/.jekyll-cache",
-    "test": "npm run lint && npm run check-links",
+    "test": "npm run check:metadata && npm run lint && npm run check-links",
     "lint": "markdownlint 'docs/**/*.md' --ignore node_modules",
     "lint:light": "markdownlint 'docs/**/*.md' --ignore node_modules",
     "check-links": "markdown-link-check -c .markdown-link-check.json docs/**/*.md",
-    "help": "echo 'Available commands:\n  npm start - Start development server\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'"
+    "help": "echo 'Available commands:\n  npm start - Start development server\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'",
+    "check:metadata": "node scripts/check-metadata-consistency.js"
   },
   "devDependencies": {
     "markdownlint-cli": "^0.37.0",
@@ -41,5 +41,5 @@
   "bugs": {
     "url": "https://github.com/itdojp/LogicalThinking-AI-Era-Guide/issues"
   },
-  "homepage": "https://github.com/itdojp/LogicalThinking-AI-Era-Guide#readme"
+  "homepage": "https://itdojp.github.io/LogicalThinking-AI-Era-Guide/"
 }

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const process = require('node:process');
+const util = require('node:util');
+
+const REPO_SLUG = 'LogicalThinking-AI-Era-Guide';
+const PACKAGE_NAME = 'logical-thinking-ai-era-guide';
+const GITHUB_URL = `https://github.com/itdojp/${REPO_SLUG}`;
+const GITHUB_GIT_URL = `${GITHUB_URL}.git`;
+const PACKAGE_GIT_URL = `git+${GITHUB_GIT_URL}`;
+const PAGES_URL = `https://itdojp.github.io/${REPO_SLUG}/`;
+const ISSUES_URL = `${GITHUB_URL}/issues`;
+const REQUIRED_DOC_ASSETS = [
+  'assets/css/main.css',
+  'assets/css/mobile-responsive.css',
+  'assets/css/syntax-highlighting.css',
+  'assets/js/theme.js',
+  'assets/js/search.js',
+  'assets/js/code-copy-lightweight.js',
+  'assets/images/itdo_logo_48x48_blue.png',
+];
+
+const root = path.resolve(__dirname, '..');
+const docsDir = path.join(root, 'docs');
+const errors = [];
+
+function repoPath(...parts) {
+  return path.join(root, ...parts);
+}
+
+function readText(relPath) {
+  try {
+    return fs.readFileSync(repoPath(relPath), 'utf8');
+  } catch (error) {
+    errors.push(`${relPath}: ${error.message}`);
+    return '';
+  }
+}
+
+function readJson(relPath) {
+  try {
+    return JSON.parse(fs.readFileSync(repoPath(relPath), 'utf8'));
+  } catch (error) {
+    errors.push(`${relPath}: invalid JSON: ${error.message}`);
+    return {};
+  }
+}
+
+function stripYamlScalar(raw) {
+  if (raw == null) return '';
+  let value = String(raw).trim();
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1);
+  }
+  return value.trim();
+}
+
+function parseRootScalars(text) {
+  const values = {};
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_]+):\s*(.*?)\s*$/);
+    if (!match) continue;
+    const [, key, raw] = match;
+    if (!raw) continue;
+    values[key] = stripYamlScalar(raw);
+  }
+  return values;
+}
+
+function parseFrontMatter(relPath) {
+  const text = readText(relPath);
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    errors.push(`${relPath}: missing YAML front matter`);
+    return {};
+  }
+  const front = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const scalar = line.match(/^([A-Za-z0-9_-]+):\s*(.*?)\s*$/);
+    if (scalar) front[scalar[1]] = stripYamlScalar(scalar[2]);
+  }
+  return front;
+}
+
+function parseNavigation(text) {
+  const sections = {};
+  let currentKey = null;
+  let currentItem = null;
+  const flush = () => {
+    if (!currentKey || !currentItem) return;
+    sections[currentKey] ??= [];
+    sections[currentKey].push(currentItem);
+    currentItem = null;
+  };
+  for (const line of text.split(/\r?\n/)) {
+    const section = line.match(/^([A-Za-z0-9_]+):\s*$/);
+    if (section) {
+      flush();
+      currentKey = section[1];
+      continue;
+    }
+    if (!currentKey) continue;
+    const title = line.match(/^\s*-\s+title:\s*(.*?)\s*$/);
+    if (title) {
+      flush();
+      currentItem = { title: stripYamlScalar(title[1]) };
+      continue;
+    }
+    const directPath = line.match(/^\s*-\s+path:\s*(.*?)\s*$/);
+    if (directPath) {
+      flush();
+      currentItem = { path: stripYamlScalar(directPath[1]) };
+      continue;
+    }
+    const itemPath = line.match(/^\s+path:\s*(.*?)\s*$/);
+    if (itemPath && currentItem) currentItem.path = stripYamlScalar(itemPath[1]);
+  }
+  flush();
+  return sections;
+}
+
+function normalizeRoute(raw, label) {
+  if (typeof raw !== 'string') {
+    errors.push(`${label}: path must be a string`);
+    return null;
+  }
+  let route = raw.trim();
+  if (!route) {
+    errors.push(`${label}: path is empty`);
+    return null;
+  }
+  if (/^(https?:|mailto:)/i.test(route)) {
+    errors.push(`${label}: external paths are not allowed (${route})`);
+    return null;
+  }
+  if (route.includes('..')) {
+    errors.push(`${label}: path must not contain '..' (${route})`);
+    return null;
+  }
+  if (!route.startsWith('/')) route = `/${route}`;
+  if (route !== '/' && !/[.]\w+$/.test(route) && !route.endsWith('/')) route += '/';
+  return route;
+}
+
+function routeCandidates(route) {
+  if (route === '/') return [path.join(docsDir, 'index.md')];
+  const rel = route.replace(/^\//, '');
+  if (rel.endsWith('/')) {
+    const dir = rel.slice(0, -1);
+    return [path.join(docsDir, dir, 'index.md'), path.join(docsDir, `${dir}.md`)];
+  }
+  return [path.join(docsDir, rel), path.join(docsDir, `${rel}.md`), path.join(docsDir, rel, 'index.md')];
+}
+
+function routeExists(route) {
+  return routeCandidates(route).some((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile());
+}
+
+function expectEqual(actual, expected, label) {
+  if (actual !== expected) errors.push(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function expectDeepEqual(actual, expected, label) {
+  if (!util.isDeepStrictEqual(actual, expected)) errors.push(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function ensureArray(value, label) {
+  if (!Array.isArray(value)) {
+    errors.push(`${label}: expected an array`);
+    return [];
+  }
+  return value;
+}
+
+const bookConfig = readJson('book-config.json');
+const packageJson = readJson('package.json');
+const packageLock = readJson('package-lock.json');
+const docsConfigText = readText('docs/_config.yml');
+const docsConfig = parseRootScalars(docsConfigText);
+const docsIndex = parseFrontMatter('docs/index.md');
+const navigation = parseNavigation(readText('docs/_data/navigation.yml'));
+const navEntries = ['introduction', 'chapters', 'additional', 'appendices']
+  .flatMap((section) => ensureArray(navigation[section] ?? [], `docs/_data/navigation.yml ${section}`)
+    .map((entry) => ({ ...entry, section })));
+const navChapters = ensureArray(navigation.chapters, 'docs/_data/navigation.yml chapters');
+const navAppendices = ensureArray(navigation.appendices, 'docs/_data/navigation.yml appendices');
+
+const canonical = {
+  title: bookConfig.title,
+  description: bookConfig.description,
+  author: bookConfig.author,
+  version: bookConfig.version,
+  license: bookConfig.license,
+};
+
+for (const [key, expected] of Object.entries(canonical)) {
+  expectEqual(bookConfig[key], expected, `book-config.json ${key}`);
+}
+expectEqual(bookConfig.language, 'ja', 'book-config.json language');
+expectEqual(bookConfig.homepage, PAGES_URL, 'book-config.json homepage');
+expectDeepEqual(bookConfig.repository, { url: GITHUB_GIT_URL, branch: 'main' }, 'book-config.json repository');
+
+expectEqual(packageJson.name, PACKAGE_NAME, 'package.json name');
+expectEqual(packageJson.version, canonical.version, 'package.json version');
+expectEqual(packageJson.description, canonical.description, 'package.json description');
+expectEqual(packageJson.author, canonical.author, 'package.json author');
+expectEqual(packageJson.license, canonical.license, 'package.json license');
+expectDeepEqual(packageJson.repository, { type: 'git', url: PACKAGE_GIT_URL }, 'package.json repository');
+expectDeepEqual(packageJson.bugs, { url: ISSUES_URL }, 'package.json bugs');
+expectEqual(packageJson.homepage, PAGES_URL, 'package.json homepage');
+expectEqual(packageJson.scripts?.['check:metadata'], 'node scripts/check-metadata-consistency.js', 'package.json scripts.check:metadata');
+if (!String(packageJson.scripts?.test || '').includes('npm run check:metadata')) {
+  errors.push('package.json scripts.test: expected to run npm run check:metadata');
+}
+
+expectEqual(packageLock.name, PACKAGE_NAME, 'package-lock.json name');
+expectEqual(packageLock.version, canonical.version, 'package-lock.json version');
+expectEqual(packageLock.packages?.['']?.name, PACKAGE_NAME, 'package-lock.json packages[""].name');
+expectEqual(packageLock.packages?.['']?.version, canonical.version, 'package-lock.json packages[""].version');
+
+for (const [key, expected] of [
+  ['title', canonical.title],
+  ['description', canonical.description],
+  ['author', canonical.author],
+  ['version', canonical.version],
+  ['lang', 'ja'],
+  ['url', 'https://itdojp.github.io'],
+  ['baseurl', `/${REPO_SLUG}`],
+  ['repository', `itdojp/${REPO_SLUG}`],
+  ['license', canonical.license],
+  ['homepage', PAGES_URL],
+  ['repository_url', GITHUB_URL],
+]) {
+  expectEqual(docsConfig[key], expected, `docs/_config.yml ${key}`);
+}
+
+for (const [key, expected] of [
+  ['title', canonical.title],
+  ['description', canonical.description],
+  ['author', canonical.author],
+  ['version', canonical.version],
+]) {
+  expectEqual(docsIndex[key], expected, `docs/index.md front matter ${key}`);
+}
+
+function structureEntries(section, label) {
+  return ensureArray(bookConfig.structure?.[section], `book-config.json structure.${section}`).map((item, index) => ({
+    id: item.id,
+    title: item.title,
+    description: item.description,
+    path: normalizeRoute(item.path, `${label}[${index}].path`),
+  }));
+}
+
+const expectedChapters = navChapters.map((item, index) => ({
+  id: `chapter${String(index + 1).padStart(2, '0')}`,
+  title: item.title,
+  description: bookConfig.structure?.chapters?.[index]?.description,
+  path: normalizeRoute(item.path, `navigation chapter ${index + 1}`),
+}));
+const expectedAppendices = navAppendices.map((item, index) => ({
+  id: `appendix-${String.fromCharCode(97 + index)}`,
+  title: item.title,
+  description: bookConfig.structure?.appendices?.[index]?.description,
+  path: normalizeRoute(item.path, `navigation appendix ${index + 1}`),
+}));
+expectDeepEqual(structureEntries('chapters', 'book-config.json structure.chapters'), expectedChapters, 'book-config.json structure.chapters');
+expectDeepEqual(structureEntries('appendices', 'book-config.json structure.appendices'), expectedAppendices, 'book-config.json structure.appendices');
+
+const seen = new Map();
+for (const [index, entry] of navEntries.entries()) {
+  const route = normalizeRoute(entry.path, `docs/_data/navigation.yml ${entry.section}[${index}].path`);
+  if (!route) continue;
+  if (seen.has(route)) {
+    errors.push(`docs/_data/navigation.yml: duplicate path ${route} at entries ${seen.get(route)} and ${index + 1}`);
+  } else {
+    seen.set(route, index + 1);
+  }
+  if (!routeExists(route)) {
+    const candidates = routeCandidates(route).map((candidate) => path.relative(root, candidate).replaceAll(path.sep, '/')).join(', ');
+    errors.push(`docs/_data/navigation.yml: path ${route} has no matching Markdown source (${candidates})`);
+  }
+}
+
+for (const route of [...expectedChapters, ...expectedAppendices].map((entry) => entry.path)) {
+  if (!seen.has(route)) errors.push(`book-config.json structure path ${route} is missing from navigation`);
+}
+
+for (const asset of REQUIRED_DOC_ASSETS) {
+  const file = path.join(docsDir, asset);
+  if (!fs.existsSync(file) || !fs.statSync(file).isFile() || fs.statSync(file).size === 0) {
+    errors.push(`docs/${asset}: required public asset is missing or empty`);
+  }
+}
+
+if (errors.length) {
+  console.error(`Metadata consistency check failed with ${errors.length} issue(s):`);
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(`OK: metadata, navigation, structure, and required assets are consistent (${navEntries.length} navigation entries)`);


### PR DESCRIPTION
## Summary
- add a stdlib-only `check:metadata` gate for package/book/Jekyll/front matter/navigation/structure/asset consistency
- align public metadata across `book-config.json`, `docs/_config.yml`, `docs/index.md`, and `package.json`
- add paths for canonical chapter/appendix structure entries and set the package/book homepage to the published Pages URL
- wire the metadata check into local `npm test` and Book QA, and document it in README

## Validation
- `node --check scripts/check-metadata-consistency.js`
- `npm run check:metadata`
- `(cd docs && node ../scripts/check-metadata-consistency.js)`
- `npm test`
- `npm audit --omit=dev --omit=optional` (0 vulnerabilities)
- `git diff --check`
- workflow YAML parse for `.github/workflows/*.yml`
- fixture checks: package homepage drift, missing navigation target, duplicate navigation target, missing structure path, external structure path fail with actionable errors; CRLF front matter positive case passes
- pinned `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4` checks: unicode, textlint/PRH, internal links, layout risk, markdown structure
- Jekyll build from `docs/` and built-site smoke for top, intro workflow, chapter01, chapter17, case study 01, appendix A, and required assets

## Notes
- `npm ci` still reports existing dev dependency audit findings; production/non-optional audit is clean.
- `docs/` content only metadata/front matter changed; no generated manuscript sync is required.