### PR TITLE
UX module設定と付録A案内を公開実体へ整合

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -137,10 +137,10 @@
       "readingGuide": true,
       "checklistPack": false,
       "troubleshootingFlow": false,
-      "conceptMap": true,
-      "figureIndex": true,
+      "conceptMap": false,
+      "figureIndex": false,
       "legalNotice": false,
-      "glossary": true
+      "glossary": false
     }
   },
   "shared": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ permalink: /
 - 概念の全体像を先に押さえる: [第1章：なぜ今、論理的思考が必要なのか](chapters/chapter01/)
 - 実務での使い方を確認する: [AI活用の標準業務フロー（1枚）](introduction/02-standard-workflow/)
 - 改稿範囲と今後の章契約を確認する: [2026年版リライト契約と分割計画](introduction/03-rewrite-plan-2026/)
-- 用語・図版・テンプレートを再利用する: [付録A：実践的なツール・テンプレート集](appendices/appendix-a/)（conceptMap / glossary / figureIndex 相当）
+- 実務テンプレートを再利用する: [付録A：実践的なツール・テンプレート集](appendices/appendix-a/)（実務オペレーティングキット）
 - 関連書籍の流れをたどる: [ITエンジニア知識アーキテクチャ](https://itdojp.github.io/it-engineer-knowledge-architecture/)
 - シリーズ横断で読む: [AI時代のプロフェッショナルITエンジニアの思考法](https://itdojp.github.io/ai-era-engineers-mind-book/)、[エンジニアのための実践コミュニケーション設計](https://itdojp.github.io/IT-engineer-communication-book/)
 


### PR DESCRIPTION
## 概要

公開Pagesに専用実体がない `conceptMap` / `figureIndex` / `glossary` をfalseへ変更し、付録Aを未実装module相当と誤案内しないようにします。

Closes #155

## 変更

- `book-config.json`: 3 modulesをfalseへ整合
- `docs/index.md`: 付録Aを「実務オペレーティングキット」として説明
- 実体の新規実装は portal `itdojp/it-engineer-knowledge-architecture#236` で追跡

## 検証

- `npm ci`
- `npm test`
- `npm run build`
- `git diff --check`

`npm audit --audit-level=moderate` の既存15件は別Issue #156で分離対応します。